### PR TITLE
Fix bug preventing alpha being set to 0.

### DIFF
--- a/fnirsi_logger.py
+++ b/fnirsi_logger.py
@@ -305,10 +305,7 @@ def main():
     refresh = 1.0 if is_fnb58_or_fnb48s else 0.003  # 1 s for FNB58 / FNB48S, 3 ms for others
     continue_time = time.time() + refresh
 
-    if args.alpha:
-        alpha = args.alpha
-    else:
-        alpha = 0.9
+    alpha = args.alpha
 
     stop = False
     while not stop:


### PR DESCRIPTION
The previous code to to set an opional value for the temperature smoothing factor alpha redundantly set alpha to the default value if no --alpha was specified. The implementation was such that --alpha=0 actually set alpha to 0.9

This commit fixes that and is also tighter code, by simply setting

`alpha = args.alpha`

and of course the call to parser.add_argument() takes care of the default value.