### PR TITLE
Sporadic lock fix and massive refactoring

### DIFF
--- a/fnirsi_logger.py
+++ b/fnirsi_logger.py
@@ -195,13 +195,15 @@ def decode(data, calculate_crc, time_interval, alpha):
 def request_data(is_fnb58_or_fnb48s, ep_out):
     # Setup communication with power meter
     ep_out.write(b"\xaa\x81" + b"\x00" * 61 + b"\x8e")
+    time.sleep(0.01) 
     ep_out.write(b"\xaa\x82" + b"\x00" * 61 + b"\x96")
+    time.sleep(0.01)
 
     if is_fnb58_or_fnb48s:
         ep_out.write(b"\xaa\x82" + b"\x00" * 61 + b"\x96")
     else:
         ep_out.write(b"\xaa\x83" + b"\x00" * 61 + b"\x9e")
-
+    time.sleep(0.01)
 
 # Argument handling
 def str2bool(v: str) -> bool:
@@ -301,7 +303,7 @@ def main():
     print()  # Extra line so concatenation work better in gnuplot.
     print("timestamp sample_in_packet voltage_V current_A dp_V dn_V temp_C_ema energy_Ws capacity_As")
 
-    time.sleep(0.1)
+    time.sleep(0.01)
     refresh = 1.0 if is_fnb58_or_fnb48s else 0.003  # 1 s for FNB58 / FNB48S, 3 ms for others
     continue_time = time.time() + refresh
 
@@ -347,6 +349,7 @@ def main():
     except Exception as e:
         print(f"Exception {type(e)} {e}", file=sys.stderr)
         raise
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request aims to fix old issue (#7). To achieve this I added small time gap between request during device initialization (8b395d35d9399de20078a7c43fcae89215d60a3f). This removes locks completely, I was able to run (previously it crashed on 3-4 iteration each time):
```bash
$ for i in (seq 1 100); echo $i; sudo ./fnirsi_logger.py &; sleep 3; kill $last_pid; end
$ for i in (seq 1 100); echo $i; sudo ./fnirsi_logger.py &; sleep 7; kill $last_pid; end
$ for i in (seq 1 100); echo $i; sudo ./fnirsi_logger.py &; sleep 13; kill $last_pid; end
```
Tested on Fnirsi FNB58, firmware v0.63/v0.68.

## Refactoring
Additional, second commit includes total refactoring:
- removed frequent
  ```python
  if args.verbose:
      print(...)
  ```
  blocks, using `logging` library
- used `int.from_bytes` instead of manual numbers conversion from little-endian bytes
- configuration and device specific options wrapped to `enum`s and `dataclasses` for type safety and further extensibility
- functionality encapsulated to separate class, allowing using your project not only as separate executable, but as library

I understand that second commit completely changes the structure of the code and you might want to not merge it to main. It's all up to you, I just wanted to share what helped me, to solve my problems